### PR TITLE
fix:修改ETF价格显示0的问题

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -143,7 +143,7 @@ class SinaStockTransform {
 		return this.fixed(this.price - this.yestclose);
 	}
 
-	fixed(n: number, q = 2) {
+	fixed(n: number, q = 3) {
 		return Math.round(n * 10 ** q) / 10 ** q;
 	}
 


### PR DESCRIPTION
ETF的tooltip中价格显示为0，修改fixed函数的第二个参数默认值为3。