### PR TITLE
feat: 增加qos.hk获取实时港美股

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ VScode 插件 | A 股 | 港股 | 期货 | 实时股票数据 | 状态栏实时�
 
 // 股票跌的颜色，默认跟随系统
 "stock-bar.fallColor": ""
+
+// 是否启用qos.hk接口获取港美股实时行情（需要配置token）
+"stock-bar.useQosForHkUs": false
+
+// qos.hk接口的token，用于获取港美股实时行情
+"stock-bar.qosHkToken": ""
 ```
 
 ## 股票配置说明

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "stock-bar",
-	"version": "1.0.9",
+	"version": "1.0.11",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "stock-bar",
-			"version": "1.0.9",
+			"version": "1.0.11",
 			"license": "MIT",
 			"dependencies": {
 				"axios": "^0.27.2"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "stock-bar",
 	"displayName": "Stock Bar",
 	"description": "股票监控，底部状态栏实时更新 A股|港股|美股|实时股票数据",
-	"version": "1.0.10",
+	"version": "1.0.11",
 	"publisher": "Chef",
 	"license": "MIT",
 	"keywords": [
@@ -69,6 +69,16 @@
 					"type": "string",
 					"default": "",
 					"description": "股票跌的颜色，默认跟随系统"
+				},
+				"stock-bar.useQosForHkUs": {
+					"type": "boolean",
+					"default": false,
+					"description": "是否启用qos.hk接口获取港美股实时行情（需要配置token）"
+				},
+				"stock-bar.qosHkToken": {
+					"type": "string",
+					"default": "",
+					"description": "qos.hk接口的token，用于获取港美股实时行情"
 				}
 			}
 		},

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -47,6 +47,20 @@ export default class Configuration {
 		return Configuration.stockBarConfig().get('fallColor');
 	}
 
+	/**
+	 * 获取是否使用qos.hk接口获取港美股实时数据
+	 */
+	static getUseQosForHkUs() {
+		return Configuration.stockBarConfig().get('useQosForHkUs') === true;
+	}
+
+	/**
+	 * 获取qos.hk接口的token
+	 */
+	static getQosHkToken() {
+		return Configuration.stockBarConfig().get('qosHkToken') as string;
+	}
+
 	static updateStocks(stocks: Record<string, string>) {
 		const newStocks: StockOptions = Object.entries(stocks).map(
 			([code, alias]) => (alias ? { code, alias } : code),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import logger from './logger';
 import Configuration from './configuration';
-import { sinaStockProvider } from './provider';
+import { stockProvider } from './provider';
 import { render, renderFutures, stopAllRender } from './render';
 import Stock from './stock';
 import FutureHandler from './futures';
@@ -44,7 +44,7 @@ async function ticker() {
 		// 从云端获取最新状态
 		logger.debug('call fetchData');
 		const [data] = await Promise.all([
-			sinaStockProvider.fetch(stocks.map((v) => v.code)),
+			stockProvider.fetch(stocks.map((v) => v.code)),
 			futureHandler.updateData(),
 		]);
 		// 更新本地的数据

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosError, AxiosInstance } from 'axios';
 import Stock from './stock';
+import Configuration from './configuration';
 
 class SinaStockTransform {
 	/**
@@ -217,4 +218,199 @@ class SinaStockProvider {
 	}
 }
 
+/**
+ * qos.hk股票查询接口
+ */
+class QosHkStockProvider {
+	httpService: AxiosInstance;
+
+	constructor() {
+		this.httpService = axios.create({
+			timeout: 10000,
+			baseURL: 'https://api.qos.hk',
+		});
+	}
+
+	/**
+	 * 将股票代码格式化为qos.hk接口需要的格式
+	 * @param codes
+	 */
+	formatCodes(codes: string[]): string[] {
+		const groups: Record<string, string[]> = {
+			US: [],
+			HK: [],
+			SH: [],
+			SZ: [],
+			CF: [],
+		};
+
+		codes.forEach((code) => {
+			const upperCode = code.toUpperCase();
+			if (upperCode.startsWith('GB_')) {
+				// 美股
+				groups.US.push(upperCode.replace('GB_', ''));
+			} else if (upperCode.startsWith('HK')) {
+				// 港股
+				groups.HK.push(upperCode.replace('HK', ''));
+			} else if (upperCode.startsWith('SH')) {
+				// 上证
+				groups.SH.push(upperCode.replace('SH', ''));
+			} else if (upperCode.startsWith('SZ')) {
+				// 深证
+				groups.SZ.push(upperCode.replace('SZ', ''));
+			}
+		});
+
+		// 构建请求格式
+		return Object.entries(groups)
+			.filter(([_, codes]) => codes.length > 0)
+			.map(([market, codes]) => `${market}:${codes.join(',')}`);
+	}
+
+	/**
+	 * 将qos.hk返回的数据转换为Stock格式
+	 * @param data
+	 */
+	transformQosData(data: any[]): Partial<Stock>[] {
+		return data.map((item) => {
+			const code = item.c.toLowerCase();
+			const prefixMap: Record<string, string> = {
+				'us:': 'gb_',
+				'hk:': 'hk',
+				'sh:': 'sh',
+				'sz:': 'sz',
+				'cf:': 'cf',
+			};
+
+			// 从原始代码中提取市场和股票代码
+			const [market, stockCode] = item.c.split(':');
+			// 构建符合现有系统的code格式
+			let formattedCode = '';
+
+			if (market.toUpperCase() === 'US') {
+				formattedCode = `gb_${stockCode.toLowerCase()}`;
+			} else {
+				formattedCode = `${market.toLowerCase()}${stockCode}`;
+			}
+
+			// 计算涨跌幅
+			const price = Number(item.lp);
+			const yestclose = Number(item.yp);
+			const percent = yestclose ? (price - yestclose) / yestclose : 0;
+			const updown = price - yestclose;
+
+			return {
+				code: formattedCode,
+				name: formattedCode, // qos.hk接口不返回名称，直接使用code
+				price: price,
+				open: Number(item.o),
+				high: Number(item.h),
+				low: Number(item.l),
+				percent: Number(percent.toFixed(4)),
+				updown: Number(updown.toFixed(3)),
+				yestclose: yestclose,
+			};
+		});
+	}
+
+	/**
+	 * 获取数据
+	 * @param codes 股票代码数组
+	 */
+	async fetch(codes: string[]) {
+		// 获取token
+		const token = Configuration.getQosHkToken();
+		if (!token) {
+			throw new Error('未配置QOS.HK的Token，请检查配置');
+		}
+
+		try {
+			// 处理请求数据格式
+			const formattedCodes = this.formatCodes(codes);
+			if (formattedCodes.length === 0) {
+				return [];
+			}
+
+			const rep = await this.httpService.post(`/snapshot?key=${token}`, {
+				codes: formattedCodes,
+			});
+
+			if (rep.data.msg !== 'OK' || !rep.data.data) {
+				throw new Error(`请求失败: ${rep.data.msg || '未知错误'}`);
+			}
+
+			return this.transformQosData(rep.data.data);
+		} catch (err: unknown) {
+			const error = err as AxiosError;
+			/**
+			 * @see https://axios-http.com/docs/handling_errors
+			 */
+			if (error.response) {
+				throw new Error(String(error.response.data));
+			}
+			if (error.request) {
+				throw new Error('The request was made but no response was received');
+			}
+			throw new Error(error.message);
+		}
+	}
+}
+
+/**
+ * 提供一个统一的接口，根据配置选择使用哪个provider
+ */
+class StockProvider {
+	private sinaProvider: SinaStockProvider;
+	private qosHkProvider: QosHkStockProvider;
+
+	constructor() {
+		this.sinaProvider = new SinaStockProvider();
+		this.qosHkProvider = new QosHkStockProvider();
+	}
+
+	/**
+	 * 获取股票数据
+	 * @param codes
+	 */
+	async fetch(codes: string[]) {
+		const useQosForHkUs = Configuration.getUseQosForHkUs();
+
+		// 如果未开启qos.hk或没有配置token，全部使用新浪接口
+		if (!useQosForHkUs || !Configuration.getQosHkToken()) {
+			return this.sinaProvider.fetch(codes);
+		}
+
+		// 把代码分为两组：港美股(qos.hk) 和 A股(新浪)
+		const hkUsCodes = codes.filter((code) => {
+			const lowerCode = code.toLowerCase();
+			return lowerCode.startsWith('hk') || lowerCode.startsWith('gb_');
+		});
+
+		const aCodes = codes.filter((code) => {
+			const lowerCode = code.toLowerCase();
+			return (
+				lowerCode.startsWith('sh') ||
+				lowerCode.startsWith('sz') ||
+				lowerCode.startsWith('bj')
+			);
+		});
+
+		const results: Partial<Stock>[] = [];
+
+		// 并行获取数据
+		if (hkUsCodes.length > 0 && aCodes.length > 0) {
+			const [hkUsData, aData] = await Promise.all([
+				this.qosHkProvider.fetch(hkUsCodes),
+				this.sinaProvider.fetch(aCodes),
+			]);
+			return [...hkUsData, ...aData];
+		} else if (hkUsCodes.length > 0) {
+			return await this.qosHkProvider.fetch(hkUsCodes);
+		} else {
+			return await this.sinaProvider.fetch(aCodes);
+		}
+	}
+}
+
 export const sinaStockProvider = new SinaStockProvider();
+export const stockProvider = new StockProvider();


### PR DESCRIPTION
#46 大陆的接口提供商由于法规要求，对于港股必须提供15分钟延时行情，所以要想实时获取必须寻找海外的API。
所以我给加上了使用qos.hk提供的API来获取实时行情，免费套餐用于个人看盘已经足够。需要加上额外的配置才能启用，不影响现有配置。